### PR TITLE
Release skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+
+out_data/*
+.remake/*

--- a/1_spatial.yml
+++ b/1_spatial.yml
@@ -1,0 +1,58 @@
+target_default: 1_spatial
+
+packages:
+  - dplyr
+  - meddle
+  - rgdal
+  - sf
+  - zip
+  
+sources:
+  - src/spatial_functions.R
+
+targets:
+  1_spatial:
+    depends:
+      - out_data/01_spatial.zip
+      - out_data/river_reach_metadata.csv
+    
+  # not sure what this metadata should be, if anything
+  # one option is to include a reach to HRU crosswalk
+  #out_data/river_reach_metadata.csv:
+   # command: create_metadata_file(target_name,
+     # streams_sf = modeled_streams_sf,
+     # stream_to_hru = 'XX')
+
+  modeled_network_sf:
+    command: retrieve_network(network_sf_fl = '../delaware-model-prep/1_network/out/network.rds')
+    
+  network_vertices_sf:
+    command: retrieve_vertices(network_sf_fl = '../delaware-model-prep/1_network/out/network.rds')
+    
+  # should include shapefile of HRUs
+  #hrus_sf:
+    #command: retrieve_hrus(hrus_sf_fl = 'XX')
+  
+  # include map of network, maybe with HRUs?
+  #out_data/modeling_domain_map.png:
+   # command: plot_domain_map(target_name,
+    #  network_sf = modeled_network_sf,
+      #plot_crs = I("+init=epsg:2811"))
+    
+  spatial_metadata:
+    command: extract_feature(network_vertices_sf)
+    
+  out_data/01_spatial_network.zip:
+    command: sf_to_zip(target_name,
+      sf_object = modeled_network_sf,
+      layer_name = I('study_stream_reaches'))
+      
+  #out_data/01_spatial_hru.zip:
+   # command: sf_to_zip(target_name,
+    #  sf_object = hrus_sf,
+     # layer_name = I('study_hrus'))
+    
+
+  
+    
+  

--- a/2_observations.yml
+++ b/2_observations.yml
@@ -1,0 +1,22 @@
+target_default: 2_observations
+
+packages:
+  - readr
+  - zip
+
+sources:
+  - src/file_functions.R
+
+targets:
+  2_observations:
+    depends:
+      - out_data/temperature_observations.zip
+      - out_data/flow_observations.zip
+
+  # daily flow and temperature data
+  out_data/temperature_observations.zip:
+    command: zip_obs(out_file = target_name, in_file = '../delaware-model-prep/2_observations/out/obs_temp_drb.rds')
+    
+  out_data/flow_observations.zip:
+    command: zip_obs(out_file = target_name, in_file = '../delaware-model-prep/2_observations/out/obs_flow_drb.rds')
+

--- a/4_inputs.yml
+++ b/4_inputs.yml
@@ -1,0 +1,32 @@
+target_default: 4_inputs
+
+include:
+
+packages:
+  - dplyr
+  - zip
+  - readr
+
+sources:
+  - src/file_functions.R
+
+targets:
+  4_inputs:
+    depends:
+      - out_data/distance_matrix.csv
+      #- out_data/weather_drivers.zip
+      #- out_data/reach_atrributes.csv
+
+  #weather_drivers:
+   # command: extract_weather_drivers()
+    
+  #out_data/weather_drivers.zip:
+   # command: zip_this(out_file = target_name, in_file = weather_drivers)
+    
+  out_data/distance_matrix.csv:
+    command: get_distance_matrix(out_file = target_name, in_file = '../delaware-model-prep/9_collaborator_data/umn/distance_matrix.rds')
+
+  #out_data/reach_attributes.csv:
+   # command: extract_reach_attributes()
+    
+    

--- a/in_text/text_00_parent.yml
+++ b/in_text/text_00_parent.yml
@@ -5,14 +5,15 @@ title: >-
 abstract: >-
   <p>Daily temperature predictions in the Delaware River Basin (DRB) can inform decision makers who can use cold-water reservoir releases to maintain thermal habitat for sensitive fish and mussel species.
   This data release provides the inputs and outputs for process-guided machine learning methods to improve prediction of water temperature across 456 river reaches in the DRB.
+
   <br/>The data are organized into these items:</p>
   <ol>
-  <li><a href="https://www.sciencebase.gov/catalog/item/XX">River Information</a> - A river reach metadata file and one shapefile of polylines for each 456 river segments in this study</li>
-  <li><a href="https://www.sciencebase.gov/catalog/item/XX">Observations</a> - Water temperature observations for XX of the 456 river reaches used in this study</li>
-  <li><a href="https://www.sciencebase.gov/catalog/item/XX">Model Configurations</a> - Model parameters and metadata used to configure models</li>
-  <li><a href="https://www.sciencebase.gov/catalog/item/XX">Model Inputs</a> - Data used to drive predictive models (distance matrices, river reach metadata, daily meteorology)</li>
-  <li><a href="https://www.sciencebase.gov/catalog/item/XX">Model Predictions</a> - Predictions of water temperature</li>
-  <li><a href="https://www.sciencebase.gov/catalog/item/XX">Model Evaluation</a> - Performance of models</li>
+  <li><a href="https://www.sciencebase.gov/catalog/item/5f6a285d82ce38aaa244912e">River Information</a> - A river reach metadata file and one shapefile of polylines for each 456 river segments in this study</li>
+  <li><a href="https://www.sciencebase.gov/catalog/item/5f6a287382ce38aaa2449131">Observations</a> - Water temperature observations for XX of the 456 river reaches used in this study</li>
+  <li><a href="https://www.sciencebase.gov/catalog/item/5f6a288982ce38aaa2449133">Model Configurations</a> - Model parameters and metadata used to configure models</li>
+  <li><a href="https://www.sciencebase.gov/catalog/item/5f6a289982ce38aaa2449135">Model Inputs</a> - Data used to drive predictive models (distance matrices, river reach metadata, daily meteorology)</li>
+  <li><a href="https://www.sciencebase.gov/catalog/item/5f6a28a782ce38aaa2449137">Model Predictions</a> - Predictions of water temperature</li>
+  <li><a href="https://www.sciencebase.gov/catalog/item/5f6a28ba82ce38aaa2449139">Model Evaluation</a> - Performance of models</li>
   <br/>
   <p>This research was funded by the USGS, XX.</p>
 

--- a/in_text/text_00_parent.yml
+++ b/in_text/text_00_parent.yml
@@ -1,0 +1,28 @@
+title: >-
+  Data release: Predicting water temperature in the Delaware River Basin
+
+
+abstract: >-
+  <p>Daily temperature predictions in the Delaware River Basin (DRB) can inform decision makers who can use cold-water reservoir releases to maintain thermal habitat for sensitive fish and mussel species.
+  This data release provides the inputs and outputs for process-guided machine learning methods to improve prediction of water temperature across 456 river reaches in the DRB.
+  <br/>The data are organized into these items:</p>
+  <ol>
+  <li><a href="https://www.sciencebase.gov/catalog/item/XX">River Information</a> - A river reach metadata file and one shapefile of polylines for each 456 river segments in this study</li>
+  <li><a href="https://www.sciencebase.gov/catalog/item/XX">Observations</a> - Water temperature observations for XX of the 456 river reaches used in this study</li>
+  <li><a href="https://www.sciencebase.gov/catalog/item/XX">Model Configurations</a> - Model parameters and metadata used to configure models</li>
+  <li><a href="https://www.sciencebase.gov/catalog/item/XX">Model Inputs</a> - Data used to drive predictive models (distance matrices, river reach metadata, daily meteorology)</li>
+  <li><a href="https://www.sciencebase.gov/catalog/item/XX">Model Predictions</a> - Predictions of water temperature</li>
+  <li><a href="https://www.sciencebase.gov/catalog/item/XX">Model Evaluation</a> - Performance of models</li>
+  <br/>
+  <p>This research was funded by the USGS, XX.</p>
+
+build-environment: Multiple computer systems were used to generate these data, including linux, OSX. The open source languages R and Python were used on all systems. XX
+
+process-date: !expr format(Sys.time(),'%Y%m%d')
+indirect-spatial: U.S.A.
+latitude-res: 0.1
+longitude-res: 0.1
+data-name: Full data release
+data-description: >-
+  This is the landing page for the other data release units, described in the attributes section
+file-format: parent data item for released data products

--- a/in_text/text_01_spatial.yml
+++ b/in_text/text_01_spatial.yml
@@ -1,5 +1,5 @@
 title: >-
-  Predicting Water Temperature Dynamics of Unmonitored Lakes with Meta Transfer Learning: 1 Lake information for 2,332 lakes
+  Predicting water temperature in the Delaware River Basin: 1 River reach information for 456 river reaches
 
 abstract: >-
   This dataset provides shapefile outlines of the 2,332 lakes that had temperature modeled as part of this study.
@@ -54,4 +54,4 @@ file-format: Shapefile Data Set
 build-environment: >-
   This dataset was generated using open source tools available in the R programming language (R version 4.0.2 (2020-06-22)).
   The computing platform for generating data and metadata was x86_64-w64-mingw32
-  R packages loaded into this environment: packagename, version: 1.1.7;  packagename2, version: 1.4.0
+  R packages loaded into this environment: packagename, version: 1.1.7;  packagename2, version: 1.4.0...

--- a/in_text/text_01_spatial.yml
+++ b/in_text/text_01_spatial.yml
@@ -1,0 +1,57 @@
+title: >-
+  Predicting Water Temperature Dynamics of Unmonitored Lakes with Meta Transfer Learning: 1 Lake information for 2,332 lakes
+
+abstract: >-
+  This dataset provides shapefile outlines of the 2,332 lakes that had temperature modeled as part of this study.
+  The format is a shapefile for all lakes combined (.shp, .shx, .dbf, and .prj files). A csv file of lake metadata is also included.
+  This dataset is part of a larger data release of lake temperature model inputs and outputs for 2,332 lakes in the U.S.
+  (https://doi.org/10.5066/P9I00WFR).
+
+cross-cites:
+
+entities:
+  -
+    data-name: 01_spatial.zip
+    data-description: GIS polylines data for the 456 stream segments included in this study
+    attributes:
+    -
+      attr-label: seg_nat_id
+      attr-def: >-
+        Stream reach identification number for this dataset. This is the ID named XX from the Geospatial Fabric for  National Hydrologic Modeling."
+      attr-defs: >-
+        https://www.sciencebase.gov/catalog/item/535eda80e4b08e65d60fc834
+      data-min: NA
+      data-max: NA
+      data-units: NA
+  -
+    data-name: stream_metadata.csv
+    data-description: Select metadata for the 456 stream reaches included in this study.
+    attributes:
+    -
+      attr-label: site_id
+      attr-def: >-
+        Stream reach identification number for this dataset. This is the ID named XX from the Geospatial Fabric for  National Hydrologic Modeling."
+      attr-defs: >-
+        https://www.sciencebase.gov/catalog/item/535eda80e4b08e65d60fc834
+      data-min: NA
+      data-max: NA
+      data-units: NA
+
+    -
+      attr-label: 
+      attr-def: 
+      attr-defs: >-
+        http://nhd.usgs.gov/
+      data-min:
+      data-max:
+      data-units:
+
+data-name: Polylines for river reaches in the study basin
+data-description: Shapefile of study river reaches included in this data release; metadata file for stream segments in this data release
+
+file-format: Shapefile Data Set
+
+build-environment: >-
+  This dataset was generated using open source tools available in the R programming language (R version 4.0.2 (2020-06-22)).
+  The computing platform for generating data and metadata was x86_64-w64-mingw32
+  R packages loaded into this environment: packagename, version: 1.1.7;  packagename2, version: 1.4.0

--- a/in_text/text_02_observations.yml
+++ b/in_text/text_02_observations.yml
@@ -1,0 +1,62 @@
+title: >-
+  Predicting water temperature in the Delaware River Basin: 2 water temperature and flow observations
+
+abstract: >-
+  Observed water temperatures from 1980-2019 were compiled for the Delaware River Basin, US. These data were used
+  as XX. The data are formatted as a single csv (comma separated values) file with attributes corresponding to the unique combination of
+  lake identifier, time, and depth. Data came from a variety of sources, including the National Water Inventory System, 
+  Water Quality Portal, and the NorEaST stream water temperature database.
+
+cross-cites:
+  -
+    authors: XX
+    title: >-
+      XX
+    pubdate: XX
+    link: XX
+
+entities:
+  -
+    data-name: temperature_observations.zip
+    data-description: Temperature observation data with sites matched to 456 model river segments in the Delaware River Basin.
+    attributes:
+    -
+      attr-label: seg_id_nat
+      attr-def: >-
+        River reach identifier from XX, which the site was matched to based on latitude and longitude.
+      attr-defs: >-
+        XX
+      data-min: NA
+      data-max: NA
+      data-units: NA
+    -
+      attr-label: site_id
+      attr-def: >-
+        Site identifier from the data provider.
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: NA
+    -
+      attr-label: date
+      attr-def: Date of temperature measurement
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: NA
+    -
+      attr-label: temp
+      attr-def: Water temperature
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: degrees C
+    -
+      attr-label: source_id
+      attr-def: The source of these data.
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: NA
+
+file-format: a single comma-delimited file, compressed into a zip file

--- a/in_text/text_02_observations.yml
+++ b/in_text/text_02_observations.yml
@@ -24,8 +24,7 @@ entities:
       attr-label: seg_id_nat
       attr-def: >-
         River reach identifier from XX, which the site was matched to based on latitude and longitude.
-      attr-defs: >-
-        XX
+      attr-defs: NA
       data-min: NA
       data-max: NA
       data-units: NA
@@ -58,5 +57,46 @@ entities:
       data-min: NA
       data-max: NA
       data-units: NA
+  -
+    data-name: flow_observations.zip
+    data-description: Flow observation data with sites matched to 456 model river segments in the Delaware River Basin.
+    attributes:
+    -
+      attr-label: seg_id_nat
+      attr-def: >-
+        River reach identifier from XX, which the site was matched to based on latitude and longitude.
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: NA
+    -
+      attr-label: site_id
+      attr-def: >-
+        Site identifier from the data provider.
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: NA
+    -
+      attr-label: date
+      attr-def: Date of temperature measurement
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: NA
+    -
+      attr-label: flow
+      attr-def: River flow or discharge
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: cubic meters per second
+    -
+      attr-label: source_id
+      attr-def: The source of these data
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: NA
 
-file-format: a single comma-delimited file, compressed into a zip file
+file-format: comma-delimited files, compressed into zip files

--- a/in_text/text_04_inputs.yml
+++ b/in_text/text_04_inputs.yml
@@ -1,0 +1,36 @@
+title: >-
+  Predicting water temperature in the Delaware River Basin: 3 model inputs
+
+abstract: >-
+  This dataset includes model inputs including gridded weather data, a stream network distance matrix, and stream reach attributes/metadata.
+  
+cross-cites:
+  -
+    authors: ['XX']
+    title: >-
+      GridMet XX
+    pubdate: XX
+    link: XX
+  -
+    authors: ['XX']
+    title: >-
+      GRanD reservoir database. XX
+    pubdate: XX
+    link: XX
+  -
+    authors: ['XX']
+    title: >-
+      Geospatial Fabric for National Hydrologic Modeling XX
+    pubdate: XX
+    link: http://dx.doi.org/doi:10.5066/F7542KMD
+    
+
+build-environment: Multiple computer systems were used to generate these data, including XX. The open source languages R and Python was used on all systems, as well as XX.
+
+process-date: !expr format(Sys.time(),'%Y%m%d')
+indirect-spatial: U.S.A.
+latitude-res: 0.1
+longitude-res: 0.1
+data-name: weather data, distance matrix, river reach metadata
+
+

--- a/in_text/text_04_inputs.yml
+++ b/in_text/text_04_inputs.yml
@@ -24,7 +24,28 @@ cross-cites:
     pubdate: XX
     link: http://dx.doi.org/doi:10.5066/F7542KMD
     
-
+entities:
+  -
+    data-name: distance_matrix.csv
+    data-description: A matrix documentation the upstream (negative numbers) or downstream (positive numbers) distances between river reaches.
+    attributes:
+    -
+      attr-label: from
+      attr-def: >-
+        The segment ID (seg_id_nat) of the starting segment for the distance calculation.
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: NA
+    -
+      attr-label: {seg_id_nat}
+      attr-def: >-
+        Distance (in meters) between the seg_id_nat in the from column to the {seg_id_nat} in the column name. Positive numbers indicate a downstream direction, while positive numbers indicate an upstream direction.
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: meters
+    
 build-environment: Multiple computer systems were used to generate these data, including XX. The open source languages R and Python was used on all systems, as well as XX.
 
 process-date: !expr format(Sys.time(),'%Y%m%d')

--- a/in_text/text_04_inputs.yml
+++ b/in_text/text_04_inputs.yml
@@ -1,5 +1,5 @@
 title: >-
-  Predicting water temperature in the Delaware River Basin: 3 model inputs
+  Predicting water temperature in the Delaware River Basin: 4 model inputs
 
 abstract: >-
   This dataset includes model inputs including gridded weather data, a stream network distance matrix, and stream reach attributes/metadata.

--- a/in_text/text_05_predictions.yml
+++ b/in_text/text_05_predictions.yml
@@ -1,0 +1,31 @@
+title: >-
+  Predicting water temperature in the Delaware River Basin: 5 model prediction data
+
+abstract: >-
+  Multiple modeling frameworks were used to predict daily temperatures at 456 stream reaches in the Delaware River Basin. Uncalibrated process-based models (PB0)
+  used default configurations (see XX for details) and no parameters were adjusted according to model fit with observations. Deep Learning (DL) models were xx.
+
+cross-cites:
+  -
+    authors: ['XX']
+    title: >-
+      Precipitation Runoff Modeling System (PRMS)
+    pubdate: XX
+    link: XX
+  -
+    authors: ['XX']
+    title: >-
+      Stream Network Temperature Model (SNTemp)
+    pubdate: XX
+    link: XX
+  -
+    authors: ['XX']
+    title: >-
+      River graph convolution network (RGCN) XX
+    pubdate: XX
+    link: XX
+
+build-environment: >-
+  For PB0 predictions we used XX; process-based predictions were generated with the following open source tools XX.
+  For PGDL and DL predictions, the University of Minnesota Supercomputing Institute resources were used. XX
+  

--- a/in_text/text_06_evaluation.yml
+++ b/in_text/text_06_evaluation.yml
@@ -1,0 +1,2 @@
+title: >-
+  Predicting water temperature in the Delaware River Basin: 6 model evaluation

--- a/in_text/text_SHARED.yml
+++ b/in_text/text_SHARED.yml
@@ -1,0 +1,68 @@
+authors: ["Samantha K. Oliver, XX"]
+pubdate: 2020
+doi: XX
+abstract: >-
+  Daily temperature predictions in the Delaware River Basin (DRB) can inform decision makers who can use cold-water reservoir releases to maintain thermal habitat for sensitive fish and mussel species.
+  This data release provides the inputs and outputs for process-guided machine learning methods to improve prediction of water temperature across 456 river reaches in the DRB.
+
+# ----associated publication----
+larger-cites:
+  -
+    authors: ["TBD XX"]
+    title: >-
+      TBD XX
+    pubdate: 2020
+
+purpose: Decision support, limnological research, and fish habitat.
+start-date: 19801001
+end-date: 20191231
+
+update: none planned
+themekeywords: ["machine learning", "deep learning", "hybrid modeling", "water","temperature","reservoirs","modeling", "XX"]
+
+usage-rules: >-
+  These data are subject to change and are not citable until reviewed and approved for official publication by the USGS
+
+descgeog: "River reach polylines as defined by the XX."
+data-publisher: U.S. Geological Survey
+
+# ----contacts----
+contact-person: Samantha K. Oliver
+contact-phone: 608-821-3824
+contact-email: soliver@usgs.gov
+contact-position: Hydrologist
+contact-address: "8505 Research Way"
+contact-city: Middleton
+contact-state: WI
+contact-zip: 53562
+
+metadata-person: Samantha K. Oliver
+metadata-position: Hydrologist
+metadata-phone: 608-821-3824
+metadata-fax: 608-821-3817
+metadata-email: soliver@usgs.gov
+metadata-address: "8505 Research Way"
+metadata-city: Middleton
+metadata-state: WI
+metadata-zip: 53562
+metadata-date: !expr format(Sys.time(),'%Y%m%d')
+
+accur-test: No formal attribute accuracy tests were conducted.
+funding-credits: >-
+  This study was funded by the Department of the Interior
+  Northeast Climate Adaptation Science Center, the United States Geological Survey National Climate
+  This research used resources of the Core Science Analytics and Synthesis Advanced Research Computing program at the U.S. Geological Survey.
+
+process-description: >-
+  At the core of the modeling framework is a coupled hydrologic-thermodynamic model that uses inputs of reach-specific properties and local meteorology to estimate flow and water temperature.
+  Our chosen model is the open source, Precipitation Runoff Modeling System (PRMS) with the coupled Stream Network Temperature Model (SNTemp) version XX. PRMS-SNTemp is a ...XX.
+  We used PRMS-SNTemp to simulate stream flow and temperature for the period of record...XX.
+  
+distro-person: Samantha K. Oliver
+liability-statement: >-
+  Unless otherwise stated, all data, metadata and related materials are considered to satisfy the quality standards relative to the purpose for which the data were collected.
+  Although these data and associated metadata have been reviewed for accuracy and completeness and approved for release by the U.S. Geological Survey (USGS),
+  no warranty expressed or implied is made regarding the display or utility of the data on any other system or for general or scientific purposes, nor shall
+  the act of distribution constitute any such warranty.
+
+

--- a/remake.yml
+++ b/remake.yml
@@ -1,0 +1,134 @@
+
+include:
+  - 1_spatial.yml
+  - 2_observations.yml
+  #- 3_config.yml
+  - 4_inputs.yml
+  #- 5_predictions.yml
+  #- 6_evaluation.yml
+
+
+packages:
+  - yaml
+  - dplyr
+  - tidyr
+  - meddle # at least v0.0.8
+  - readr
+  - feather
+  - rgdal
+  - stringr
+  - sf
+  - sbtools
+  - dssecrets
+
+sources:
+  #- src/spatial_utils.R
+  - src/sb_functions.R
+
+targets:
+  all:
+    depends:
+      - 00_parent_sb_xml
+      - 01_spatial_sb_xml
+      - 01_spatial_sb_shp
+      #- 01_spatial_sb_data
+      - 02_observations_sb_data
+      - 02_observations_sb_xml
+      #- 03_config_sb_xml
+      #- 03_config_sb_data
+      - 04_inputs_sb_xml
+      - 04_inputs_sb_data
+      #- 05_predictions_sb_xml
+      #- 05_predictions_sb_sntemp
+      #- 06_evaluation_sb_data
+      #- 06_evaluation_sb_xml
+
+
+# in case you want to mess w/ the xml alone:
+  out_xml/00_parent.xml:
+    command: render(filename = target_name,
+      "in_text/text_SHARED.yml",
+      "in_text/text_00_parent.yml")
+
+  00_parent_sb_xml:
+    command: sb_render_post_xml(sbid_00_parent,
+      "in_text/text_SHARED.yml",
+      "in_text/text_00_parent.yml",
+      spatial_metadata)
+
+  01_spatial_sb_xml:
+    command: sb_render_post_xml(sbid_01_spatial,
+      "in_text/text_SHARED.yml",
+      "in_text/text_01_spatial.yml",
+      spatial_metadata)
+
+  01_spatial_sb_shp:
+    command: sb_replace_files(sbid_01_spatial,
+      "out_data/01_spatial_network.zip")
+  #01_spatial_sb_data:
+   # command: sb_replace_files(sbid_01_spatial,
+    #  "out_data/lake_metadata.csv")
+  
+  02_observations_sb_data:
+    command: sb_replace_files(sbid_02_observations,
+      "out_data/temperature_observations.zip", "out_data/flow_observations.zip")
+
+  02_observations_sb_xml:
+    command: sb_render_post_xml(sbid_02_observations,
+      "in_text/text_SHARED.yml",
+      "in_text/text_02_observations.yml",
+      spatial_metadata)
+
+  04_inputs_sb_xml:
+    command: sb_render_post_xml(sbid_04_inputs,
+      "in_text/text_SHARED.yml",
+      "in_text/text_04_inputs.yml")
+
+  04_inputs_sb_data:
+    command: sb_replace_files(sbid_04_inputs,
+      "out_data/distance_matrix.csv")
+
+  #05_predictions_sb_xml:
+   # command: sb_render_post_xml(sbid_05_predictions,
+    #  "in_text/text_SHARED.yml",
+     # "in_text/text_05_predictions.yml",
+      #spatial_metadata)
+
+  #05_predictions_sb_sntemp:
+   # command: sb_replace_files(sbid_05_predictions,
+    #  file_hash = "out/5_pb0_predict_zips.yml")
+
+  #06_evaluation_sb_xml:
+   # command: sb_render_post_xml(sb_id_06_evaluation,
+    #  "in_text/text_SHARED.yml",
+     # "in_text/text_06_evaluation.yml",
+      #spatial_metadata)
+
+  #06_evaluation_sb_data:
+   # command: sb_replace_files(sb_id_06_evaluation,
+    #  "out_data/sntemp_matched_to_observations.zip",
+     # "out_data/sntemp_evaluation.csv")
+
+  # ------ SB IDs --------
+
+
+  sbid_00_parent:
+    command: c(I('5f6a26af82ce38aaa2449100'))
+
+  sbid_01_spatial:
+    command: c(I('5f6a285d82ce38aaa244912e'))
+
+  sbid_02_observations:
+    command: c(I('5f6a287382ce38aaa2449131'))
+
+  sbid_03_config:
+    command: c(I('5f6a288982ce38aaa2449133'))
+
+  sbid_04_inputs:
+    command: c(I('5f6a289982ce38aaa2449135'))
+
+  sbid_05_predictions:
+    command: c(I('5f6a28a782ce38aaa2449137'))
+
+  sb_id_06_evaluation:
+    command: c(I('5f6a28ba82ce38aaa2449139'))

--- a/src/file_functions.R
+++ b/src/file_functions.R
@@ -1,0 +1,33 @@
+zip_this <- function(out_file, .object){
+  
+  if ('data.frame' %in% class(.object)){
+    filepath <- basename(out_file) %>% tools::file_path_sans_ext() %>% paste0('.csv') %>% file.path(tempdir(), .)
+    write_csv(.object, path = filepath)
+    zip_this(out_file = out_file, .object = filepath)
+  } else if (class(.object) == 'character' & file.exists(.object)){
+    # for multiple files?
+    curdir <- getwd()
+    on.exit(setwd(curdir))
+    setwd(dirname(.object))
+    zip::zip(file.path(curdir, out_file), files = basename(.object))
+  } else {
+    stop("don't know how to zip ", .object)
+  }
+}
+
+zip_obs <- function(out_file, in_file){
+  
+  zip_this(out_file, .object = readRDS(in_file))
+  
+}
+
+get_distance_matrix <- function(out_file, in_file) {
+  distance <- readRDS(in_file)
+  from <- rownames(distance$updown)
+
+  out <- as_tibble(distance$updown) %>%
+    mutate(from = from) %>%
+    select(from, everything())
+  
+  readr::write_csv(out, path = out_file) 
+}

--- a/src/sb_functions.R
+++ b/src/sb_functions.R
@@ -1,0 +1,34 @@
+sb_replace_files <- function(sb_id, ..., file_hash){
+  
+  if (!sbtools::is_logged_in()){
+
+    sb_secret <- dssecrets::get_dssecret("cidamanager-sb-srvc-acct")
+    sbtools::authenticate_sb(username = sb_secret$username, password = sb_secret$password)
+
+  }
+  
+  hashed_filenames <- c()
+  if (!missing(file_hash)){
+    hashed_filenames <- yaml.load_file(file_hash) %>% names %>% sort() %>% rev()
+    for (file in hashed_filenames){
+      item_replace_files(sb_id, files = file)
+    }
+  }
+  files <- c(...)
+  if (length(files) > 0){
+    item_replace_files(sb_id, files = files)
+  }
+  
+}
+
+sb_render_post_xml <- function(sb_id, ..., xml_file = NULL){
+  
+  if (is.null(xml_file)){
+    xml_file <- file.path(tempdir(), paste0(sb_id,'.xml'))
+  }
+  
+  render(filename = xml_file, ...)
+  
+  sb_replace_files(sb_id = sb_id, xml_file)
+  
+}

--- a/src/spatial_functions.R
+++ b/src/spatial_functions.R
@@ -1,0 +1,32 @@
+retrieve_network <- function(network_sf_fl) {
+  network <- readRDS(network_sf_fl)
+  out <- network$edges
+  out <- sf::st_transform(out, crs = 4326)
+  return(out)
+}
+
+retrieve_vertices <- function(network_sf_fl) {
+  network <- readRDS(network_sf_fl)
+  out <- network$vertices
+  out <- sf::st_transform(out, crs = 4326) %>% as_Spatial()
+  return(out)
+}
+
+sf_to_zip <- function(zip_filename, sf_object, layer_name){
+  cdir <- getwd()
+  on.exit(setwd(cdir))
+  dsn <- tempdir()
+  
+  sf_out <- dplyr::select(sf_object, seg_id_nat, geometry)
+  
+  sf::st_write(sf_out, dsn = dsn, layer = layer_name, driver="ESRI Shapefile", delete_dsn=TRUE) # overwrites
+  
+  files_to_zip <- data.frame(filepath = dir(dsn, full.names = TRUE), stringsAsFactors = FALSE) %>%
+    mutate(filename = basename(filepath)) %>%
+    filter(str_detect(string = filename, pattern = layer_name)) %>% pull(filename)
+
+  setwd(dsn)
+  # zip::zip works across platforms
+  zip::zip(file.path(cdir, zip_filename), files = files_to_zip)
+  setwd(cdir)
+}


### PR DESCRIPTION
Skeleton of a [DRB data release](https://www.sciencebase.gov/catalog/item/5f6a26af82ce38aaa2449100) to support PGDL stream temperature modeling. I included placeholders, and some rough documentation for the XML for files I did include. Note that I inserted `XX` where edits need to be made. 

This mostly copies the PGMTL data release, with 6 main components. **Bolded files**  have already been included and pushed to SB, the rest need to be added

1. River information: **network shapefile**, HRU shapefile, map of network
2. Observations: **flow and temperature observations that have been matched to the network and reduced to reach-days**
3. Model config: placeholder in case we do GLM modeling in reservoirs, could potentially be some PRMS-SNTemp config?
4. Model inputs: **distance matrix**, weather drivers, reach attributes
5. Model predictions: sntemp predictions, sntemp intermediates, any hybrid results from collabs
6. Evaluation: RMSE of each model (by reach?)