### PR TITLE
Combine water level data

### DIFF
--- a/2_observations.yml
+++ b/2_observations.yml
@@ -62,9 +62,32 @@ targets:
       in_repo = I('../lake-temperature-model-prep/'),
       site_ids = reservoir_modeling_site_ids)
     
-  out_data/reservoir_level_obs.rds:
+  out_data/reservoir_level_nwis.rds:
     command: fetch_filter_tibble(
       out_rds = target_name,
       in_ind = '../lake-temperature-model-prep/7a_nwis_munge/out/drb_reservoirs_waterlevels_munged.rds.ind',
       in_repo = I('../lake-temperature-model-prep/'),
       site_ids = reservoir_modeling_site_ids)
+      
+  out_data/reservoir_level_nycdep.rds:
+    command: fetch_filter_tibble(
+      out_rds = target_name,
+      in_ind = '../lake-temperature-model-prep/7a_nwis_munge/out/NYC_DEP_reservoir_waterlevels.rds.ind',
+      in_repo = I('../lake-temperature-model-prep/'),
+      site_ids = reservoir_modeling_site_ids)
+      
+  out_data/reservoir_level_usgs_historical.rds:
+    command: fetch_filter_historical(
+      out_rds = target_name,
+      in_ind = '../delaware-model-prep/2_observations/out/interpolated_daily_reservoir_water_budget_components.csv.ind',
+      in_repo = I('../delaware-model-prep/'),
+      xwalk = I(c('Cannonsville' = 'nhdhr_120022743', 'Pepacton' = 'nhdhr_151957878')),
+      site_ids = reservoir_modeling_site_ids)
+      
+  out_data/reservoir_level_obs.rds:
+    command: combine_level_sources(
+      out_rds = target_name,
+      nwis_levels = 'out_data/reservoir_level_nwis.rds',
+      nyc_levels = 'out_data/reservoir_level_nycdep.rds',
+      hist_levels = 'out_data/reservoir_level_usgs_historical.rds')
+      

--- a/2_observations.yml
+++ b/2_observations.yml
@@ -82,8 +82,7 @@ targets:
       out_rds = target_name,
       in_ind = '../delaware-model-prep/2_observations/out/interpolated_daily_reservoir_water_budget_components.csv.ind',
       in_repo = I('../delaware-model-prep/'),
-      xwalk = I(c('Cannonsville' = 'nhdhr_120022743', 'Pepacton' = 'nhdhr_151957878')),
-      site_ids = reservoir_modeling_site_ids)
+      xwalk = I(c('Cannonsville' = 'nhdhr_120022743', 'Pepacton' = 'nhdhr_151957878')))
       
   out_data/reservoir_level_obs.rds:
     command: combine_level_sources(

--- a/2_observations.yml
+++ b/2_observations.yml
@@ -3,6 +3,7 @@ target_default: 2_observations
 packages:
   - readr
   - zip
+  - zoo
 
 sources:
   - src/file_functions.R

--- a/src/fetch_filter_functions.R
+++ b/src/fetch_filter_functions.R
@@ -29,6 +29,20 @@ fetch_filter_tibble <- function(out_rds, in_ind, in_repo, site_ids) {
     saveRDS(out_rds)
 }
 
+fetch_filter_historical <- function(out_rds, in_ind, in_repo, xwalk, site_ids) {
+  # pull the data file down to that other repo
+  gd_get_elsewhere(gsub(in_repo, '', in_ind, fixed=TRUE), in_repo)
+
+    # read and filter to just the specified sites
+  as_data_file(in_ind) %>%
+    readr::read_csv(col_types = 'ccnnncnnnnnnnnnc') %>%
+    mutate(site_id = xwalk[reservoir]) %>%
+    filter(site_id %in% !!site_ids) %>%
+    filter(!is.na(res_level_m)) %>%
+    select(site_id, date, res_level_m, data_type) %>%
+    saveRDS(out_rds)
+}
+
 fetch_filter_nml <- function(out_rds, in_ind, in_repo, site_ids) {
   # pull the data file down to that other repo
   gd_get_elsewhere(gsub(in_repo, '', in_ind, fixed=TRUE), in_repo)

--- a/src/fetch_filter_functions.R
+++ b/src/fetch_filter_functions.R
@@ -29,15 +29,15 @@ fetch_filter_tibble <- function(out_rds, in_ind, in_repo, site_ids) {
     saveRDS(out_rds)
 }
 
-fetch_filter_historical <- function(out_rds, in_ind, in_repo, xwalk, site_ids) {
+fetch_filter_historical <- function(out_rds, in_ind, in_repo, xwalk) {
   # pull the data file down to that other repo
   gd_get_elsewhere(gsub(in_repo, '', in_ind, fixed=TRUE), in_repo)
-
+  browser()
     # read and filter to just the specified sites
   as_data_file(in_ind) %>%
     readr::read_csv(col_types = 'ccnnncnnnnnnnnnc') %>%
     mutate(site_id = xwalk[reservoir]) %>%
-    filter(site_id %in% !!site_ids) %>%
+    filter(site_id %in% as.character(xwalk)) %>%
     filter(!is.na(res_level_m)) %>%
     select(site_id, date, res_level_m, data_type) %>%
     saveRDS(out_rds)


### PR DESCRIPTION
Combining the observed reservoir water level data from NWIS pulls, NYC DEP-provided data, and historical USGS data/reports provided by the NY WSC. Though Hayley has shown these sources are near identical, I kept data in this order: NWIS, NYC-DEP, then historical USGS. I chose the historical data last so that daily observed data would be prioritized over the monthly interpolated data from the historical USGS data. 

A few questions:

1) I think the next step is to interpolate between observations that come from the NYC DEP data in the early part of the record (see graph below). Unlike the monthly to daily interpolation where we just assumed the same value over the month, we would need to consider how to interpolate between irregularly sampled dates. Just linear interpolation between points? 
2) From the reservoir meeting notes, I think we decided to keep the estimated (from surface area) water level data out of the release?

```
dat <- readRDS('out_data/reservoir_level_obs.rds')

ggplot(dat, aes(x = date, y = surface_elevation_m)) +
    geom_point(aes(color = source, shape = data_type), alpha = 0.1) +
    facet_wrap(~site_id, nrow = 2, scales = 'free') +
    theme_bw()
```
![image](https://user-images.githubusercontent.com/15788176/116770089-b2ba1f80-aa06-11eb-97f4-d19b447c2f2b.png)
