### PR TITLE
Remove obs

### DIFF
--- a/2_observations.yml
+++ b/2_observations.yml
@@ -71,7 +71,7 @@ targets:
       site_ids = reservoir_modeling_site_ids)
       
   out_data/reservoir_level_nycdep.rds:
-    command: fetch_filter_tibble(
+    command: fetch_filter_nycdep(
       out_rds = target_name,
       in_ind = '../lake-temperature-model-prep/7a_nwis_munge/out/NYC_DEP_reservoir_waterlevels.rds.ind',
       in_repo = I('../lake-temperature-model-prep/'),

--- a/4_inputs.yml
+++ b/4_inputs.yml
@@ -23,7 +23,7 @@ targets:
       - out_data/reservoir_features_lordville.csv
       - out_data/sntemp_inputs_outputs.zip
       - out_data/sntemp_inputs_outputs_lordville.zip
-      - out_data/reservoir_interpolated_daily_reservoir_water_budget_components.csv
+      - out_data/reservoir_interpolated_daily_water_budget_components.csv
       - log/reservoir_meteo_files.yml
       
   #weather_drivers:

--- a/in_text/text_02_observations.yml
+++ b/in_text/text_02_observations.yml
@@ -54,9 +54,25 @@ entities:
       data-max: NA
       data-units: NA
     -
-      attr-label: temp_c
+      attr-label: mean_temp_c
       attr-def: >-
-        Water temperature
+        Mean daily water temperature
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: degrees C
+    -
+      attr-label: min_temp_c
+      attr-def: >-
+        Minimum daily water temperature
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: degrees C
+    -
+      attr-label: max_temp_c
+      attr-def: >-
+        Maximum daily water temperature
       attr-defs: NA
       data-min: NA
       data-max: NA
@@ -99,9 +115,25 @@ entities:
       data-max: NA
       data-units: NA
     -
-      attr-label: temp_c
+      attr-label: mean_temp_c
       attr-def: >-
-        Water temperature
+        Mean daily water temperature
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: degrees C
+    -
+      attr-label: min_temp_c
+      attr-def: >-
+        Minimum daily water temperature
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: degrees C
+    -
+      attr-label: max_temp_c
+      attr-def: >-
+        Maximum daily water temperature
       attr-defs: NA
       data-min: NA
       data-max: NA
@@ -144,7 +176,7 @@ entities:
       data-max: NA
       data-units: NA
     -
-      attr-label: discharge
+      attr-label: discharge_cms
       attr-def: >-
         River flow or discharge
       attr-defs: NA
@@ -189,7 +221,7 @@ entities:
       data-max: NA
       data-units: NA
     -
-      attr-label: discharge
+      attr-label: discharge_cms
       attr-def: >-
         River flow or discharge
       attr-defs: NA
@@ -402,6 +434,22 @@ entities:
       data-max: NA
       data-units: NA
     -
+      attr-label: date
+      attr-def: >-
+        Date of temperature observation
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: NA
+    -
+      attr-label: dateTime
+      attr-def: >-
+        Datetime of temperature observation
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: NA
+    -
       attr-label: source_id
       attr-def: >-
         Site identifier from the data provider.
@@ -410,9 +458,9 @@ entities:
       data-max: NA
       data-units: NA
     -
-      attr-label: date
+      attr-label: source
       attr-def: >-
-        Date of temperature observation
+        Data provider.
       attr-defs: NA
       data-min: NA
       data-max: NA
@@ -438,6 +486,22 @@ entities:
     data-description: Daily water level observations for the Pepacton and Cannonsville reservoirs.
     attributes:
     -
+      attr-label: date
+      attr-def: >-
+        Date of temperature observation
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: NA
+    -
+      attr-label: source
+      attr-def: >-
+        Data provider
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: NA
+    -
       attr-label: site_id
       attr-def: >-
         Reservoir identification number for this dataset. Is the Prmnn_I from NHD high-res prefixed with source, as "nhdhr_{Prmnn_I}"
@@ -454,14 +518,6 @@ entities:
       data-max: NA
       data-units: NA
     -
-      attr-label: date
-      attr-def: >-
-        Date of temperature observation
-      attr-defs: NA
-      data-min: NA
-      data-max: NA
-      data-units: NA
-    -
       attr-label: surface_elevation_m
       attr-def: >-
         Elevation of reservoir surface
@@ -469,5 +525,13 @@ entities:
       data-min: 329.184
       data-max: 390.6561
       data-units: meters
+    -
+      attr-label: data_type
+      attr-def: >-
+        Type of data - observed daily value (daily observed) or linearly interpolated daily value (daily interpolated)
+      attr-defs: NA
+      data-min: NA
+      data-max: NA
+      data-units: NA
 
 file-format: comma-delimited files (some compressed into zip files), rds files, feather files.

--- a/src/fetch_filter_functions.R
+++ b/src/fetch_filter_functions.R
@@ -32,8 +32,8 @@ fetch_filter_tibble <- function(out_rds, in_ind, in_repo, site_ids) {
 fetch_filter_historical <- function(out_rds, in_ind, in_repo, xwalk) {
   # pull the data file down to that other repo
   gd_get_elsewhere(gsub(in_repo, '', in_ind, fixed=TRUE), in_repo)
-  browser()
-    # read and filter to just the specified sites
+
+  # read and filter to just the specified sites
   as_data_file(in_ind) %>%
     readr::read_csv(col_types = 'ccnnncnnnnnnnnnc') %>%
     mutate(site_id = xwalk[reservoir]) %>%

--- a/src/fetch_filter_functions.R
+++ b/src/fetch_filter_functions.R
@@ -29,6 +29,20 @@ fetch_filter_tibble <- function(out_rds, in_ind, in_repo, site_ids) {
     saveRDS(out_rds)
 }
 
+fetch_filter_nycdep <- function(out_rds, in_ind, in_repo, site_ids) {
+  # pull the data file down to that other repo
+  gd_get_elsewhere(gsub(in_repo, '', in_ind, fixed=TRUE), in_repo)
+  
+  # read and filter to just the specified sites
+  nycdep_data <- as_data_file(in_ind) %>%
+    readRDS() %>%
+    filter(site_id %in% !!site_ids)
+  
+  # filter out erroneous Pepacton observation and save as rds
+  nycdep_data <- nycdep_data[!(nycdep_data$site_id=="nhdhr_151957878" & nycdep_data$date=='1999-06-21'),] %>%
+    saveRDS(out_rds)
+}
+
 fetch_filter_historical <- function(out_rds, in_ind, in_repo, xwalk) {
   # pull the data file down to that other repo
   gd_get_elsewhere(gsub(in_repo, '', in_ind, fixed=TRUE), in_repo)


### PR DESCRIPTION
Remove single erroneous Pepacton obs

Noticed a weird NYCDEP obs on 6/21/1999 in Pepacton. It's 371.2m, and the daily obs on either side are 388.3 (6/8/99) and 387.2 (7/7/99):

![res_levels_nhdhr_151957878](https://user-images.githubusercontent.com/54007288/117486945-f85b7880-af2f-11eb-8ecc-ddf50985e3c3.png)

Sam did some digging to see if there was a potential draw down for repair or something...but coudln't find an obvious citation to that. She decided that the sudden water level drop does not look real, and would have to be something reservoir-specific since Cannonsville does not show the same pattern. We decided to filter it out prior to interpolation.

I already pushed the updated `reservoir_level_obs.rds` to [SB](https://www.sciencebase.gov/catalog/item/5f6a287382ce38aaa2449131)